### PR TITLE
Change existing block-related code to use the idea of block "modifiers"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ running the [ELCI](https://github.com/rozukke/ELCI) plugin and using C++. It is 
 This library is based on [mcpi](https://github.com/martinohanlon/mcpi), which is a Python library with similar functionality. 
 
 In addition to C++ support, this library implements several new commands supported by [ELCI](https://github.com/rozukke/ELCI):
-- `getBlocksWithData` to get a cuboid of blocks with data in a performant manner,
+- `getBlocks` to get a cuboid of blocks with modifiers in a performant manner,
 - `getHeights` to get a 2D area of heights in a performant manner,
 - `doCommand` to perform an in-game minecraft command which allows for additional functionality.
 

--- a/include/mcpp/block.h
+++ b/include/mcpp/block.h
@@ -4,23 +4,22 @@ namespace mcpp {
     class BlockType {
     public:
         int id;
-        int data;
-    public:
-        constexpr BlockType(int id, int data = 0) : id(id), data(data) {};
+        int mod;
+
+        constexpr BlockType(int id, int modifier = 0) : id(id), mod(modifier) {};
 
         /**
-        * Watch out as this also compares the BlockType.id element of the block, so some equalities may behave in
-        * somewhat unexpected ways e.g. rotated stairs
+        * Watch out as this also compares the BlockType.mod element of the block, so some equalities may behave in
+        * unexpected ways e.g. rotated stairs
         */
         bool operator==(const BlockType& other) const;
 
         /**
-        * Returns a new BlockType object with the specified data. Useful when providing a BlockType to a
-        * function that accepts them to quickly modify.
-        * @param newData Integer representing the data for the BlockType
-        * @return New BlockType object with the specified data
+        * Returns a new BlockType with the same id and specified modifier, useful for rotations etc.
+        * @param modifier New modifier for the BlockType
+        * @return New BlockType object with the specified modifier
         */
-        [[nodiscard]] BlockType withData(int data) const;
+        [[nodiscard]] BlockType withMod(int modifier) const;
     };
 
 

--- a/include/mcpp/mcpp.h
+++ b/include/mcpp/mcpp.h
@@ -68,39 +68,20 @@ namespace mcpp {
                        const BlockType& blockType);
 
         /**
-         * Returns BlockType object of the specified Coordinate loc location (this does not provide the
-         * block.data element)
+         * Returns BlockType object from the specified Coordinate loc with modifier
          * @param loc
          * @return BlockType of the requested block
          */
         BlockType getBlock(const Coordinate& loc);
 
         /**
-         * Same functionality as getBlockWithData but provides the Block.data element in the returned BlockType
-         * @param loc
-         * @return
-         */
-        BlockType getBlockWithData(const Coordinate& loc);
-
-        // TODO: specify the way to iterate through the returned list in correct order
-        /**
-         * Returns a vector of the BlockTypes at the requested cuboid. Be careful with order of iteration when
-         * parsing the returned data.
-         * @param loc1
-         * @param loc2
-         * @return Vector of BlockType's in the specified cuboid.
+         * Returns a 3D vector of the BlockTypes of the requested cuboid with modifiers
+         * @param loc1 1st corner of the cuboid
+         * @param loc2 2nd corner of the cuboid
+         * @return 3D vector of BlockType in the specified cuboid.
          */
         std::vector<std::vector<std::vector<BlockType>>>
         getBlocks(const Coordinate& loc1, const Coordinate& loc2);
-
-        /**
-         * Same functionality as getBlocks but with the additional BlockType.data element.
-         * @param loc1
-         * @param loc2
-         * @return Vector of BlockType's at the requested cuboid.
-         */
-        std::vector<std::vector<std::vector<BlockType>>>
-        getBlocksWithData(const Coordinate& loc1, const Coordinate& loc2);
 
         /**
          * IMPORTANT: DO NOT USE FOR LARGE AREAS, IT WILL BE VERY SLOW

--- a/src/block.cpp
+++ b/src/block.cpp
@@ -2,10 +2,10 @@
 
 namespace mcpp {
     bool BlockType::operator==(const BlockType& other) const {
-        return this->id == other.id && this->data == other.data;
+        return this->id == other.id && this->mod == other.mod;
     }
 
-    BlockType BlockType::withData(int newData) const {
-        return {this->id, newData};
+    BlockType BlockType::withMod(int modifier) const {
+        return {this->id, modifier};
     }
 }

--- a/src/mcpp.cpp
+++ b/src/mcpp.cpp
@@ -51,7 +51,7 @@ namespace mcpp {
     void MinecraftConnection::setBlock(const Coordinate& loc,
                                        const BlockType& blockType) {
         conn->sendCommand("world.setBlock", loc.x, loc.y, loc.z, blockType.id,
-                          blockType.data);
+                          blockType.mod);
     }
 
 
@@ -61,57 +61,29 @@ namespace mcpp {
         auto [x, y, z] = loc1;
         auto [x2, y2, z2] = loc2;
         conn->sendCommand("world.setBlocks", x, y, z, x2, y2, z2, blockType.id,
-                          blockType.data);
+                          blockType.mod);
     }
 
 
     BlockType MinecraftConnection::getBlock(const Coordinate& loc) {
-        std::string returnValue = conn->sendReceiveCommand("world.getBlock",
-                                                           loc.x, loc.y, loc.z);
-        return {std::stoi(returnValue)};
-    }
-
-
-    BlockType MinecraftConnection::getBlockWithData(const Coordinate& loc) {
         std::string returnString = conn->sendReceiveCommand(
                 "world.getBlockWithData", loc.x, loc.y, loc.z);
         std::vector<int> parsedInts;
         splitCommaStringToInts(returnString, parsedInts);
 
-        // Data and id
+        // Values are id and mod
         return {parsedInts[0], parsedInts[1]};
     }
 
-
     std::vector<std::vector<std::vector<BlockType>>>
-    MinecraftConnection::getBlocks(const Coordinate& loc1,
-                                   const Coordinate& loc2) {
-        std::string returnValue = conn->sendReceiveCommand("world.getBlocks",
-                                                           loc1.x, loc1.y,
-                                                           loc1.z,
-                                                           loc2.x, loc2.y,
-                                                           loc2.z);
-        std::stringstream ss(returnValue);
-        std::string container;
-        std::vector<BlockType> returnVector;
-
-        while (std::getline(ss, container, ',')) {
-            returnVector.emplace_back(std::stoi(container));
-        }
-
-        return unflattenBlocksArray(loc1, loc2, returnVector);
-    }
-
-
-    std::vector<std::vector<std::vector<BlockType>>>
-    MinecraftConnection::getBlocksWithData(
+    MinecraftConnection::getBlocks(
             const Coordinate& loc1, const Coordinate& loc2) {
         std::string returnValue = conn->sendReceiveCommand(
                 "world.getBlocksWithData",
                 loc1.x, loc1.y, loc1.z,
                 loc2.x, loc2.y, loc2.z);
 
-        // Received in format 1,2;1,2;1,2 where 1,2 is a block of type 1 and data 2
+        // Received in format 1,2;1,2;1,2 where 1,2 is a block of type 1 and mod 2
         std::vector<BlockType> result;
         std::stringstream stream(returnValue);
 

--- a/test/local_tests.cpp
+++ b/test/local_tests.cpp
@@ -69,10 +69,10 @@ TEST_CASE("Test block class") {
         CHECK((testBlock == testBlockRHS));
     }
 
-    SUBCASE("Test withData") {
+    SUBCASE("Test withMod") {
         BlockType testBlock(10);
         BlockType testBlockRHS(10, 2);
-        CHECK((testBlock.withData(2) == testBlockRHS));
+        CHECK((testBlock.withMod(2) == testBlockRHS));
 
     }
 }

--- a/test/minecraft_tests.cpp
+++ b/test/minecraft_tests.cpp
@@ -83,12 +83,12 @@ TEST_CASE("Test the main mcpp class") {
 
     // Using values from the Blocks struct in block.h beyond this point
 
-    SUBCASE("getBlockWithData") {
+    SUBCASE("getBlock with mod") {
         mc.setBlock(testLoc, BlockType(5, 5));
-        CHECK((mc.getBlockWithData(testLoc) == BlockType(5, 5)));
+        CHECK((mc.getBlock(testLoc) == BlockType(5, 5)));
 
         mc.setBlock(testLoc, Blocks::LIGHT_BLUE_CONCRETE);
-        CHECK((mc.getBlockWithData(testLoc) == Blocks::LIGHT_BLUE_CONCRETE));
+        CHECK((mc.getBlock(testLoc) == Blocks::LIGHT_BLUE_CONCRETE));
     }
 
     SUBCASE("getHeight") {
@@ -142,7 +142,7 @@ TEST_CASE("Test the main mcpp class") {
         CHECK((returnVector == expected));
     }
 
-    SUBCASE("getBlocksWithData") {
+    SUBCASE("getBlocks with mod") {
         mc.setBlocks(testLoc, testLoc2, Blocks::GRANITE);
 
         auto expected = std::vector<std::vector<std::vector<BlockType>>>(
@@ -156,7 +156,7 @@ TEST_CASE("Test the main mcpp class") {
                 )
         );
 
-        std::vector returnVector = mc.getBlocksWithData(testLoc, testLoc2);
+        std::vector returnVector = mc.getBlocks(testLoc, testLoc2);
 
         CHECK((returnVector == expected));
     }


### PR DESCRIPTION
This should hopefully remove the ambiguity of `getBlocks` vs `getBlocksWithData` as well as the unclear `data` component of `BlockType`s. I don't see any reason why you would not want the `mod` (the new name for `data`) with each request, and if it is unnecessary it can be easily overwritten.