### PR TITLE
Fix flooring in split function

### DIFF
--- a/src/mcpp.cpp
+++ b/src/mcpp.cpp
@@ -1,6 +1,7 @@
 #include "../include/mcpp/mcpp.h"
 #include <string>
 #include <vector>
+#include <cmath>
 
 using std::string_view;
 using namespace std::string_literals;
@@ -12,7 +13,10 @@ namespace mcpp {
         std::stringstream ss(str);
         std::string item;
         while (std::getline(ss, item, ',')) {
-            vec.push_back(std::stoi(item));
+            // Fixes flooring issue w/ negative coordinates
+            double itemDouble = std::stod(item);
+            int itemFloored = static_cast<int>(std::floor(itemDouble));
+            vec.push_back(itemFloored);
         }
     }
 

--- a/test/minecraft_tests.cpp
+++ b/test/minecraft_tests.cpp
@@ -179,6 +179,12 @@ TEST_CASE("Player operations") {
         Coordinate playerLoc = mc.getPlayerPosition();
         CHECK((playerLoc == (testLoc + Coordinate(0, 1, 0))));
     }
+
+    SUBCASE("Check correct flooring") {
+        Coordinate negativeLoc(-2, 100, -2);
+        mc.doCommand("tp -2 100 -2");
+        CHECK_EQ(mc.getPlayerPosition(), negativeLoc);
+    }
 }
 
 #endif


### PR DESCRIPTION
When teleporting in Minecraft, the player is placed at a .5 increment, which was getting rounded instead of floored.