### PR TITLE
Fixed Small Documentation Error

### DIFF
--- a/include/mcpp/mcpp.h
+++ b/include/mcpp/mcpp.h
@@ -84,7 +84,7 @@ namespace mcpp {
         /**
          * IMPORTANT: DO NOT USE FOR LARGE AREAS, IT WILL BE VERY SLOW
          * USE getHeights() INSTEAD
-         * Gets the y-value of the highest non-air block at the specified (x, y) coordinate.
+         * Gets the y-value of the highest non-air block at the specified (x, z) coordinate.
          * @param x
          * @param z
          * @return Returns the integer y-height at the requested coordinate.


### PR DESCRIPTION
- Changed documenation for method mcpp::getHeight as it said "(x,y) coordinate" as opposed to "(x,z) coordinate"