### PR TITLE
Add != operator to Coordinate Class

### DIFF
--- a/include/mcpp/util.h
+++ b/include/mcpp/util.h
@@ -16,6 +16,7 @@ namespace mcpp {
         Coordinate operator+(const Coordinate& obj) const;
 
         bool operator==(const Coordinate& obj) const;
+        bool operator!=(const Coordinate& obj) const;
 
         Coordinate operator-(const Coordinate& obj) const;
 

--- a/include/mcpp/util.h
+++ b/include/mcpp/util.h
@@ -16,6 +16,7 @@ namespace mcpp {
         Coordinate operator+(const Coordinate& obj) const;
 
         bool operator==(const Coordinate& obj) const;
+
         bool operator!=(const Coordinate& obj) const;
 
         Coordinate operator-(const Coordinate& obj) const;
@@ -29,3 +30,4 @@ namespace mcpp {
         int z;
     };
 }
+

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -26,6 +26,10 @@ namespace mcpp {
         return (this->x == obj.x) && (this->y == obj.y) && (this->z == obj.z);
     }
 
+    bool Coordinate::operator!=(const Coordinate& obj) const {
+        return !((*this) == obj);
+    }
+
     Coordinate Coordinate::operator-(const Coordinate& obj) const {
         Coordinate result;
         result.x = this->x - obj.x;

--- a/test/local_tests.cpp
+++ b/test/local_tests.cpp
@@ -35,6 +35,13 @@ TEST_CASE("Test Coordinate class") {
 
         CHECK_EQ(testCoord, testCoordRHS);
     }
+    
+    SUBCASE("Test inequals") {
+        Coordinate testCoord(3, 2, 1);
+        Coordinate testCoordRHS(2, 2, 1);
+
+        CHECK_NE(testCoord, testCoordRHS);
+    }
 
     SUBCASE("Test add") {
         Coordinate testCoord(3, 2, 1);

--- a/test/local_tests.cpp
+++ b/test/local_tests.cpp
@@ -35,11 +35,12 @@ TEST_CASE("Test Coordinate class") {
 
         CHECK_EQ(testCoord, testCoordRHS);
     }
-    
-    SUBCASE("Test inequals") {
+
+    SUBCASE("Test not equals") {
         Coordinate testCoord(3, 2, 1);
         Coordinate testCoordRHS(2, 2, 1);
 
+        CHECK(testCoord != testCoordRHS);
         CHECK_NE(testCoord, testCoordRHS);
     }
 


### PR DESCRIPTION
This pull request adds support for the != inequality operator to the Coordinate class. This enhancement allows for more intuitive and direct comparison of Coordinate objects. 

Changes include:
- Overloading the != operator in the Coordinate class.
- Adding unit tests to ensure correct functionality of the != operator.

Please review the changes and provide feedback.