### PR TITLE
Remove tests from default CMake config

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,5 @@
-add_executable(local_tests local_tests.cpp)
-add_executable(test_suite local_tests.cpp minecraft_tests.cpp)
+add_executable(local_tests EXCLUDE_FROM_ALL local_tests.cpp)
+add_executable(test_suite EXCLUDE_FROM_ALL local_tests.cpp minecraft_tests.cpp)
 
 target_link_libraries(local_tests ${PROJECT_NAME})
 target_link_libraries(test_suite ${PROJECT_NAME})


### PR DESCRIPTION
Running `sudo make install` will no longer built the test suite.