### PR TITLE
Add default ctor and != for BlockType

### DIFF
--- a/include/mcpp/block.h
+++ b/include/mcpp/block.h
@@ -8,6 +8,7 @@ namespace mcpp {
         int id;
         int mod;
 
+        BlockType() = default;
         constexpr BlockType(int id, int modifier = 0) : id(id), mod(modifier) {};
 
         /**
@@ -15,6 +16,8 @@ namespace mcpp {
         * unexpected ways e.g. rotated stairs
         */
         bool operator==(const BlockType& other) const;
+
+        bool operator!=(const BlockType& other) const;
 
         friend std::ostream& operator<< (std::ostream& out, const BlockType& block);
 

--- a/src/block.cpp
+++ b/src/block.cpp
@@ -5,6 +5,10 @@ namespace mcpp {
         return this->id == other.id && this->mod == other.mod;
     }
 
+    bool BlockType::operator!=(const BlockType& other) const {
+        return !(*this == other);
+    }
+
     BlockType BlockType::withMod(int modifier) const {
         return {this->id, modifier};
     }

--- a/test/local_tests.cpp
+++ b/test/local_tests.cpp
@@ -3,7 +3,6 @@
 #include "doctest.h"
 #include "../include/mcpp/util.h"
 #include "../include/mcpp/block.h"
-#include "../include/mcpp/entity.h"
 
 using namespace mcpp;
 
@@ -70,10 +69,29 @@ TEST_CASE("Test Coordinate class") {
 }
 
 TEST_CASE("Test block class") {
+
+    SUBCASE("Default ctor") {
+        BlockType def;
+        CHECK_EQ(def.id, 0);
+        CHECK_EQ(def.mod, 0);
+    }
+
     SUBCASE("Test equality") {
         BlockType testBlock(10, 2);
         BlockType testBlockRHS(10, 2);
         CHECK_EQ(testBlock, testBlockRHS);
+    }
+
+    SUBCASE("Test non equality") {
+        BlockType testBlock(10);
+        BlockType testBlockRHS(11);
+        CHECK(testBlock != testBlockRHS);
+        CHECK_NE(testBlock, testBlockRHS);
+
+        BlockType testBlockWithMod(10, 2);
+        BlockType testBlockWithModRHS(10, 3);
+        CHECK(testBlockWithMod != testBlockWithModRHS);
+        CHECK_NE(testBlockWithMod, testBlockWithModRHS);
     }
 
     SUBCASE("Test withMod") {


### PR DESCRIPTION
Should make some built-ins easier to work with.