### PR TITLE
Fix BlockType default constructor

### DIFF
--- a/include/mcpp/block.h
+++ b/include/mcpp/block.h
@@ -8,7 +8,7 @@ namespace mcpp {
         int id;
         int mod;
 
-        BlockType() = default;
+        BlockType();
         constexpr BlockType(int id, int modifier = 0) : id(id), mod(modifier) {};
 
         /**

--- a/src/block.cpp
+++ b/src/block.cpp
@@ -1,6 +1,8 @@
 #include "../include/mcpp/block.h"
 
 namespace mcpp {
+    BlockType::BlockType(): id(0), mod(0) {}
+    
     bool BlockType::operator==(const BlockType& other) const {
         return this->id == other.id && this->mod == other.mod;
     }


### PR DESCRIPTION
## Description

The default constructor for the `BlockType` class does not specify initial values for id and mod.

![image](https://github.com/rozukke/mcpp/assets/144138246/3a3513ea-d886-4480-b2b2-461ace7428ed)
