### PR TITLE
Fix getPlayerTilePosition() and add corresponding test case

### DIFF
--- a/src/mcpp.cpp
+++ b/src/mcpp.cpp
@@ -49,7 +49,7 @@ void MinecraftConnection::setPlayerTilePosition(const Coordinate& tile) {
 }
 
 Coordinate MinecraftConnection::getPlayerTilePosition() {
-    std::string returnString = conn->sendReceiveCommand("player.", "");
+    std::string returnString = conn->sendReceiveCommand("player.getTile", "");
     std::vector<int> parsedInts;
     splitCommaStringToInts(returnString, parsedInts);
     return Coordinate(parsedInts[0], parsedInts[1], parsedInts[2]);

--- a/test/minecraft_tests.cpp
+++ b/test/minecraft_tests.cpp
@@ -153,19 +153,6 @@ TEST_CASE("Test the main mcpp class") {
 
         CHECK_EQ(returnVector, expected);
     }
-
-    SUBCASE("setPlayerTilePosition and getPlayerTilePosition") {
-        Coordinate testLoc1(180.6, 100.9, 154.7);
-        Coordinate testLoc2(testLoc1.x, testLoc1.y - 1, testLoc1.z);
-
-        mc.setBlock(testLoc2, Blocks::DIRT);
-        mc.setPlayerTilePosition(testLoc1);
-
-        Coordinate result = mc.getPlayerTilePosition();
-        Coordinate expected(180, 100, 154);
-
-        CHECK_EQ(result, expected);
-    }
 }
 
 // Requires player joined to server, will throw serverside if player is not
@@ -190,6 +177,19 @@ TEST_CASE("Player operations") {
         Coordinate negativeLoc(-2, 100, -2);
         mc.doCommand("tp -2 100 -2");
         CHECK_EQ(mc.getPlayerPosition(), negativeLoc);
+    }
+    
+    SUBCASE("setPlayerTilePosition and getPlayerTilePosition") {
+        Coordinate testLoc1(180.6, 100.9, 154.7);
+        Coordinate testLoc2(testLoc1.x, testLoc1.y - 1, testLoc1.z);
+
+        mc.setBlock(testLoc2, Blocks::DIRT);
+        mc.setPlayerTilePosition(testLoc1);
+
+        Coordinate result = mc.getPlayerTilePosition();
+        Coordinate expected(180, 100, 154);
+
+        CHECK_EQ(result, expected);
     }
 }
 

--- a/test/minecraft_tests.cpp
+++ b/test/minecraft_tests.cpp
@@ -178,7 +178,7 @@ TEST_CASE("Player operations") {
         mc.doCommand("tp -2 100 -2");
         CHECK_EQ(mc.getPlayerPosition(), negativeLoc);
     }
-    
+
     SUBCASE("setPlayerTilePosition and getPlayerTilePosition") {
         Coordinate testLoc1(180.6, 100.9, 154.7);
         Coordinate testLoc2(testLoc1.x, testLoc1.y - 1, testLoc1.z);

--- a/test/minecraft_tests.cpp
+++ b/test/minecraft_tests.cpp
@@ -153,6 +153,19 @@ TEST_CASE("Test the main mcpp class") {
 
         CHECK_EQ(returnVector, expected);
     }
+
+    SUBCASE("setPlayerTilePosition and getPlayerTilePosition") {
+        Coordinate testLoc1(180.6, 100.9, 154.7);
+        Coordinate testLoc2(testLoc1.x, testLoc1.y - 1, testLoc1.z);
+
+        mc.setBlock(testLoc2, Blocks::DIRT);
+        mc.setPlayerTilePosition(testLoc1);
+
+        Coordinate result = mc.getPlayerTilePosition();
+        Coordinate expected(180, 100, 154);
+
+        CHECK_EQ(result, expected);
+    }
 }
 
 // Requires player joined to server, will throw serverside if player is not


### PR DESCRIPTION
### Description
This pull request fixes the incomplete command in the `getPlayerTilePosition()` function.

**Changes:**
- Updated the command from `player.` to `player.getTile`.
- Added corresponding test case for getPlayerTilePosition() and setPlayerTilePosition()

### Linked Issue
This pull request fixes #28 