### PR TITLE
Fix get/set(PlayerTilePosition) offset by 1

### DIFF
--- a/src/mcpp.cpp
+++ b/src/mcpp.cpp
@@ -47,7 +47,7 @@ Coordinate MinecraftConnection::getPlayerPosition() {
 void MinecraftConnection::setPlayerTilePosition(const Coordinate& tile) {
     Coordinate newTile = tile;
     newTile.y++;
-    conn->sendCommand("player.setTile", newTile.x, newTile.y, newTile.z);
+    setPlayerPosition(newTile);
 }
 
 Coordinate MinecraftConnection::getPlayerTilePosition() {

--- a/src/mcpp.cpp
+++ b/src/mcpp.cpp
@@ -45,14 +45,15 @@ Coordinate MinecraftConnection::getPlayerPosition() {
 }
 
 void MinecraftConnection::setPlayerTilePosition(const Coordinate& tile) {
-    conn->sendCommand("player.setTile", tile.x, tile.y, tile.z);
+    Coordinate newTile = tile;
+    newTile.y++;
+    conn->sendCommand("player.setTile", newTile.x, newTile.y, newTile.z);
 }
 
 Coordinate MinecraftConnection::getPlayerTilePosition() {
-    std::string returnString = conn->sendReceiveCommand("player.getTile", "");
-    std::vector<int> parsedInts;
-    splitCommaStringToInts(returnString, parsedInts);
-    return Coordinate(parsedInts[0], parsedInts[1], parsedInts[2]);
+    Coordinate playerTile = getPlayerPosition();
+    playerTile.y--;
+    return playerTile;
 }
 
 void MinecraftConnection::setBlock(const Coordinate& loc,


### PR DESCRIPTION
## Related Issue
Fixes #30  

## Type of Change
- Offset getTilePosition by -1
- Offset setTilePosition by +1

**Tested with test_suite**
```
----------------------------------------------------------

2/2 Testing: full
2/2 Test: full
Command: "/mnt/c/Users/yeefh/documents/mcpp/build/test/test_suite"
Directory: /mnt/c/Users/yeefh/documents/mcpp/build
"full" start time: Jun 12 00:07 AEST
Output:
----------------------------------------------------------
[doctest] doctest version is "2.4.9"
[doctest] run with "--help" for options
===============================================================================
[doctest] test cases:  6 |  6 passed | 0 failed | 0 skipped
[doctest] assertions: 40 | 40 passed | 0 failed |
[doctest] Status: SUCCESS!
<end of output>
Test time =   0.92 sec
----------------------------------------------------------
Test Passed.
"full" end time: Jun 12 00:07 AEST
"full" time elapsed: 00:00:00
----------------------------------------------------------

End testing: Jun 12 00:07 AEST
```