### PR TITLE
Update cpp-linter.yml to show format error locations

### DIFF
--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -7,6 +7,11 @@ on:
     branches: main
     paths: ['**.cpp', '**.h', '**CMakeLists.txt']
 
+permissions:
+    contents: write
+    pull-requests: write
+    actions: write
+
 jobs:
   cpp-linter:
     runs-on: ubuntu-latest
@@ -19,7 +24,9 @@ jobs:
         with:
           style: 'file'  # Use .clang-format config file. 
           tidy-checks: '-*' # disable clang-tidy checks. 
+          thread-comments: true
+          format-review: true
 
-      - name: Fast fail
+      - name: Run clang-format
         if: steps.linter.outputs.clang-format-checks-failed > 0
         run: exit 1


### PR DESCRIPTION
### Description: ###
This pull request fixes the issue where the C++ linter workflow in the CI pipeline did not show specific locations of format errors, making it difficult to identify and fix them. The cpp-linter.yml file for GitHub Actions has been updated to provide detailed error messages, including file names and line numbers where the formatting errors are found.

### Changes: ###
- Updated the cpp-linter.yml configuration to enable detailed error output.

### Testing: ###
- Tested these changes on my repository and confirmed that the linter now provides detailed error messages.

### Linked Issue: ###
This pull request fixes #35 

