### PR TITLE
Add CI workflow for building and testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CD
+name: CI
 
 on:
     push:
@@ -9,7 +9,7 @@ on:
         paths: ['**.cpp', '**.h', '**CMakeLists.txt']
 
 jobs:
-    deploy:
+    build-and-test:
         runs-on: ubuntu-latest
         steps:
             - name: Install Java

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,6 @@ jobs:
             - name: Build file
               run: cmake -Bbuild
 
-            - name: Run  local_tests
+            - name: Run test suite
               working-directory: ./build
-              run: make local_tests && ./test/local_tests
-
-            - name: Run test_suite
-              working-directory: ./build
-              run: make test_suite && ./test/test_suite
+              run: make test_suite && ctest -R full

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,17 +3,38 @@ name: CD
 on:
     push:
         branches: main
+        paths: ['**.cpp', '**.h', '**CMakeLists.txt'] 
+    pull_request:
+        branches: main
+        paths: ['**.cpp', '**.h', '**CMakeLists.txt']
 
 jobs:
-    build:
+    deploy:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
-            - name: build
+            - name: Install Java
+              uses: actions/setup-java@v4
+              with:
+                distribution: 'oracle' # See 'Supported distributions' for available options
+                java-version: '17'
+            
+            - name: Clone Minecraft_Tools
+              run: git clone https://github.com/nhatdongdang/Minecraft_Tools
+
+            - name: Start Spigot Server
+              working-directory: ./Minecraft_Tools/server
+              run: nohup java -Xms512M -Xmx1024M -jar -DIReallyKnowWhatIAmDoingISwear spigot-1.19.4.jar nogui -o true & sleep 45
+
+            - name: Clone mcpp
+              uses: actions/checkout@v4
+
+            - name: Build file
               run: cmake -Bbuild
-            - name:  local_tests
+
+            - name: Run  local_tests
               working-directory: ./build
               run: make local_tests && ./test/local_tests
-            - name: test_suite
+
+            - name: Run test_suite
               working-directory: ./build
-              run: make local_tests && ./test/local_tests
+              run: make test_suite && ./test/test_suite

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,19 @@
+name: CD
+
+on:
+    push:
+        branches: main
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: build
+              run: cmake -Bbuild
+            - name:  local_tests
+              working-directory: ./build
+              run: make local_tests && ./test/local_tests
+            - name: test_suite
+              working-directory: ./build
+              run: make local_tests && ./test/local_tests


### PR DESCRIPTION
## Overview
This pull request adds a new CI workflow for building and testing the mcpp library.
## Changes Made
- Added a new GitHub Actions workflow file for CI.
- Configured the workflow to run on `ubuntu-latest`.
- Included steps for setting up Java, cloning repositories, starting the Spigot server, building the project, and running tests.
## Notes
- Won't work for test cases that depend on the player joining the server
## Linked issue 
#26 