### PR TITLE
Implement GitHub Action for Spigot Server Startup and Player Join

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,27 +12,9 @@ jobs:
     build-and-test:
         runs-on: ubuntu-latest
         steps:
-            # Install Oracle Java 17 using the setup-java GitHub Action
-            - name: Install Java
-              uses: actions/setup-java@v4
-              with:
-                distribution: 'oracle' # Specify the distribution of Java
-                java-version: '17' # Specify the version of Java to install
-            
-            # Clone the Minecraft_Tools repository from GitHub, which includes all necessary tools for the Spigot server and player joining
-            - name: Clone Minecraft_Tools
-              run: git clone https://github.com/nhatdongdang/Minecraft_Tools
-
-            # Start the Spigot server using terminal commands
-            - name: Start Spigot Server
-              working-directory: ./Minecraft_Tools/server
-              run: nohup java -Xms512M -Xmx1024M -jar -DIReallyKnowWhatIAmDoingISwear spigot-1.19.4.jar nogui -o true & sleep 45
-
-            # Join the Spigot server using the precompiled Minecraft-Console-Client (https://github.com/MCCTeam/Minecraft-Console-Client). 
-            # The config file: https://github.com/nhatdongdang/Minecraft_Tools/blob/main/MinecraftClient/MinecraftClient.ini
-            - name: Join Spigot Server
-              working-directory: ./Minecraft_Tools/MinecraftClient
-              run: ./MinecraftClient &
+            # Start and join the Spigot Server
+            - name: Set up Minecraft testing environment
+              uses: nhatdongdang/mc-env-setup@v1
 
             # Checkout the mcpp repository for building and testing
             - name: Checkout mcpp

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -23,6 +23,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           style: 'file'  # Use .clang-format config file. 
+          version: 18
           tidy-checks: '-*' # disable clang-tidy checks. 
           thread-comments: true
           format-review: true

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -23,7 +23,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           style: 'file'  # Use .clang-format config file. 
-          version: 18
           tidy-checks: '-*' # disable clang-tidy checks. 
           thread-comments: true
           format-review: true


### PR DESCRIPTION
## Description 
This pull request aims to resolve the issue of tests running before players successfully joined the Spigot server in the CI workflow.

## Changes made
- Integrated a GitHub Action that:
    - Starts the Spigot server.
    - Waits for players to join the server.
    - Ensures tests are executed only after players have successfully joined.
## Linked issues
- #44 