### PR TITLE
Fix for iterator type error in example pyramid.cpp

### DIFF
--- a/example/pyramid.cpp
+++ b/example/pyramid.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <vector>
 #include <mcpp/block.h>
 #include <mcpp/mcpp.h>
 #include <mcpp/util.h>
@@ -30,8 +31,15 @@ int main() {
         mc.getHeights(ORIGIN, ORIGIN + mcpp::Coordinate(pyramid_base_len, 0,
                                                         pyramid_base_len));
 
+    std::vector<int> height_vals;
+    for (int x = 0; x < heights.x_len(); ++x) {
+        for (int z = 0; z < heights.z_len(); ++z) {
+            height_vals.push_back(heights.get(x, z));
+        }
+    }
+
     // Use minimum height of the area as the lowest point on the pyramid
-    int min_height = *std::min_element(heights.begin(), heights.end());
+    int min_height = *std::min_element(height_vals.begin(), height_vals.end());
 
     // Build rings, diminishing up to pyramid height
     mcpp::Coordinate base_pt = heights.base_pt();
@@ -41,3 +49,4 @@ int main() {
         make_ring(base_pt + mcpp::Coordinate(i, i, i), side_len - (i * 2));
     }
 }
+

--- a/example/pyramid.cpp
+++ b/example/pyramid.cpp
@@ -31,11 +31,10 @@ int main() {
         mc.getHeights(ORIGIN, ORIGIN + mcpp::Coordinate(pyramid_base_len, 0,
                                                         pyramid_base_len));
 
+    // Convert heights of build area to vector
     std::vector<int> height_vals;
-    for (int x = 0; x < heights.x_len(); ++x) {
-        for (int z = 0; z < heights.z_len(); ++z) {
-            height_vals.push_back(heights.get(x, z));
-        }
+    for (const auto& height : heights) {
+        height_values.push_back(height);
     }
 
     // Use minimum height of the area as the lowest point on the pyramid
@@ -49,4 +48,3 @@ int main() {
         make_ring(base_pt + mcpp::Coordinate(i, i, i), side_len - (i * 2));
     }
 }
-


### PR DESCRIPTION
Pyramid example doesn't work due to mcpp::HeightMap not supporting direct iteration over the heights stored in array.

See below.

```
rowan@kinson:~/Code/rmit/studio/examples$ mining pyramid_broken
===============================================
MINING: Compiling pyramid_broken.cc into pyramid_broken
===============================================
In file included from pyramid_broken.cc:1:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/algorithm:1751:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__algorithm/copy.h:15:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__algorithm/min.h:14:
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__algorithm/min_element.h:55:3: error: static assertion failed due to requirement '__has_iterator_category_convertible_to<mcpp::HeightMap::Iterator, std::forward_iterator_tag, false>::value': std::min_element requires a ForwardIterator
  static_assert(__has_forward_iterator_category<_ForwardIterator>::value,
  ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__algorithm/min_element.h:67:19: note: in instantiation of function template specialization 'std::min_element<mcpp::HeightMap::Iterator, std::__less<void, void>>' requested here
    return _VSTD::min_element(__first, __last, __less<>());
                  ^
pyramid_broken.cc:36:28: note: in instantiation of function template specialization 'std::min_element<mcpp::HeightMap::Iterator>' requested here
    int min_height = *std::min_element(heights.begin(), heights.end());
                           ^
1 error generated.
===============================================
MINING: Executing pyramid_broken
===============================================
mining:13: no such file or directory: ./pyramid_broken
```

Wrote rudimentary fix for the pyramid example, which extracts height values numbers into vector for std::min_element to work.