### PR TITLE
No pragma once in Connection.h

### DIFF
--- a/include/mcpp/connection.h
+++ b/include/mcpp/connection.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cstdint>
 #include <iostream>
 #include <sstream>


### PR DESCRIPTION
Missing Pragma Once in Connection.h may cause SockectConnection to be defined multiple times.