### PR TITLE
Revamp `Coordinate` constructors

### DIFF
--- a/include/mcpp/util.h
+++ b/include/mcpp/util.h
@@ -19,11 +19,16 @@ struct Coordinate {
     /**
      * @brief Constructs a Coordinate object with integer values.
      *
-     * @param x The x-coordinate. Default is 0.
-     * @param y The y-coordinate. Default is 0.
-     * @param z The z-coordinate. Default is 0.
+     * @param x The x-coordinate.
+     * @param y The y-coordinate.
+     * @param z The z-coordinate.
      */
-    Coordinate(int x = 0, int y = 0, int z = 0);
+    Coordinate(int x, int y, int z);
+
+    /**
+     * @brief Constructs a Coordinate object with zero values.
+     */
+    Coordinate() : x(0), y(0), z(0) {}
 
     /**
      * @brief Constructs a Coordinate object with double values.

--- a/include/mcpp/util.h
+++ b/include/mcpp/util.h
@@ -23,7 +23,7 @@ struct Coordinate {
      * @param y The y-coordinate. Default is 0.
      * @param z The z-coordinate. Default is 0.
      */
-    explicit Coordinate(int x = 0, int y = 0, int z = 0);
+    Coordinate(int x = 0, int y = 0, int z = 0);
 
     /**
      * @brief Constructs a Coordinate object with double values.

--- a/include/mcpp/util.h
+++ b/include/mcpp/util.h
@@ -23,7 +23,7 @@ struct Coordinate {
      * @param y The y-coordinate.
      * @param z The z-coordinate.
      */
-    Coordinate(int x, int y, int z);
+    Coordinate(int x, int y, int z) : x(x), y(y), z(z) {}
 
     /**
      * @brief Constructs a Coordinate object with zero values.
@@ -37,7 +37,9 @@ struct Coordinate {
      * @param y The y-coordinate as a double.
      * @param z The z-coordinate as a double.
      */
-    Coordinate(double x, double y, double z);
+    Coordinate(double x, double y, double z)
+        : x(static_cast<int>(x)), y(static_cast<int>(y)),
+          z(static_cast<int>(z)) {}
 
     /**
      * @brief Adds two Coordinate objects.

--- a/include/mcpp/util.h
+++ b/include/mcpp/util.h
@@ -23,12 +23,12 @@ struct Coordinate {
      * @param y The y-coordinate.
      * @param z The z-coordinate.
      */
-    Coordinate(int x, int y, int z) : x(x), y(y), z(z) {}
+    constexpr Coordinate(int x, int y, int z) : x(x), y(y), z(z) {}
 
     /**
      * @brief Constructs a Coordinate object with zero values.
      */
-    Coordinate() : x(0), y(0), z(0) {}
+    constexpr Coordinate() : x(0), y(0), z(0) {}
 
     /**
      * @brief Constructs a Coordinate object with double values.
@@ -37,7 +37,7 @@ struct Coordinate {
      * @param y The y-coordinate as a double.
      * @param z The z-coordinate as a double.
      */
-    Coordinate(double x, double y, double z)
+    constexpr Coordinate(double x, double y, double z)
         : x(static_cast<int>(x)), y(static_cast<int>(y)),
           z(static_cast<int>(z)) {}
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5,18 +5,6 @@
 
 namespace mcpp {
 
-Coordinate::Coordinate(int x, int y, int z) {
-    this->x = x;
-    this->y = y;
-    this->z = z;
-}
-
-Coordinate::Coordinate(double x, double y, double z) {
-    this->x = static_cast<int>(x);
-    this->y = static_cast<int>(y);
-    this->z = static_cast<int>(z);
-}
-
 Coordinate Coordinate::operator+(const Coordinate& obj) const {
     Coordinate result;
     result.x = this->x + obj.x;


### PR DESCRIPTION
- Add `constexpr`
- Remove `explicit`
- Use list initialization
- Disallow omitting `y` and `z` arguments **(breaking change)**
